### PR TITLE
Support bracket matching

### DIFF
--- a/languages/rescript/brackets.scm
+++ b/languages/rescript/brackets.scm
@@ -1,0 +1,3 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)


### PR DESCRIPTION
As the title says – I use Zed w/ ReScript w/ VIM keybindings. Currently, bracket matching via `%` does not work. This PR should fix that 😄 

Inspired by https://github.com/zed-industries/zed/pull/6784