### PR TITLE
Change server path to be platform-agnostic

### DIFF
--- a/src/rescript.rs
+++ b/src/rescript.rs
@@ -1,7 +1,7 @@
 use std::{env, fs};
 use zed_extension_api::{self as zed, Result};
 
-const SERVER_PATH: &str = "node_modules/.bin/rescript-language-server";
+const SERVER_PATH: &str = "node_modules/@rescript/language-server/out/cli.js";
 const PACKAGE_NAME: &str = "@rescript/language-server";
 
 struct ReScriptExtension {


### PR DESCRIPTION
Updated the server path to point to the actual JavaScript file, ensuring compatibility on Windows. The previous path caused issues with execution on non Unix-based systems due to the way [`bin` script generation behaves in Node.js](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#bin).

