### PR TITLE
Add GitHub Actions workflow for Zed extension releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    name: Release Zed Extension
+    runs-on: ubuntu-latest
+    steps:
+      - uses: huacnlee/zed-extension-action@v2
+        with:
+          extension-name: rescript
+          push-to: rescript-lang/zed-extensions
+        env:
+          # the personal access token should have "repo" & "workflow" scopes
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
TODO:

- Fork the [zed-industries/extensions repo](https://github.com/zed-industries/extensions) to `rescipt-lang/zed-extensions`
- Config the secret `COMMITTER_TOKEN`