### PR TITLE
Support experimental language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,29 @@ This extension plugs in the following projects:
 - [tree-sitter-rescript](https://github.com/rescript-lang/tree-sitter-rescript) parser
 - [@rescript/language-server](https://github.com/rescript-lang/rescript-vscode) LSP
 
+## How test the experimental server
+
+> TODO
+
 ## Settings
 
 ```json
   "lsp": {
     "rescript-language-server": {
+      // Settings for stable server
       "initialization_options": {
         "extensionConfiguration": {
           "askToStartBuild": false
         }
       },
       "settings": {
-        "version": "1.71.0-next-441959d.0"
+        "version": "1.71.0-next-441959d.0",
+        // Server settings for experimental server go inside `rescript` key
+        "rescript": {
+          "hover": {
+            "supportMarkdownLinks": true,
+          },
+        },
       }
     }
   },
@@ -26,7 +37,7 @@ This extension plugs in the following projects:
 
 `initialization_options` are passed to the language server when it is started. They can be used to configure the language server. See [extensionConfiguration](https://github.com/rescript-lang/rescript-vscode/blob/441959d1feeaaffc1a589687758b1fbe1f649e72/server/src/config.ts#L5-L29)
 
-`settings` are specific to the Zed extension.
+The `settings.version` are specific to the Zed extension.
 With `version` you can point to a specific npm version of the [@rescript/language-server](https://www.npmjs.com/package/@rescript/language-server?activeTab=versions).
 
 ## Developing

--- a/README.md
+++ b/README.md
@@ -1,49 +1,81 @@
 # rescript-zed
 
-ReScript support for [Zed](https://zed.dev) editor.
+ReScript support for the [Zed](https://zed.dev) editor.
 
 This extension plugs in the following projects:
 
-- [tree-sitter-rescript](https://github.com/rescript-lang/tree-sitter-rescript) parser
-- [@rescript/language-server](https://github.com/rescript-lang/rescript-vscode) LSP
+- [tree-sitter-rescript](https://github.com/rescript-lang/tree-sitter-rescript)
+  parser
+- [@rescript/language-server](https://www.npmjs.com/package/@rescript/language-server)
+  LSP
 
-## How test the experimental server
+## Installing the language server
 
-> TODO
+The stable server is the default language server used by this extension. It uses
+the pre-v2 versions of `@rescript/language-server`, and the extension installs
+and updates that package automatically.
 
-## Settings
+Use `settings.version` when you need to pin a specific npm version. If it is
+omitted, Zed installs the latest published stable version.
 
-```json
+> [!NOTE]
+> The experimental server is the v2 language server published to npm under the
+> `dev` tag. Pin the package to the current `dev` version. See the version
+> history on
+> [npm](https://www.npmjs.com/package/@rescript/language-server?activeTab=versions).
+
+> [!TIP]
+> You can install the language server globally with
+> `npm i -g @rescript/language-server@dev` and set the binary path.
+>
+> ```json
+> {
+>   "lsp": {
+>     "rescript-language-server": {
+>       "binary": {
+>         "path": "rescript-language-server"
+>       }
+>     }
+>   }
+> }
+> ```
+
+### Settings
+
+```jsonc
+{
   "lsp": {
     "rescript-language-server": {
-      // Settings for stable server
+      // Server configuration for pre-v2 should be passed through initialization_options
       "initialization_options": {
         "extensionConfiguration": {
-          "askToStartBuild": false
-        }
+          "askToStartBuild": false,
+        },
       },
       "settings": {
         "version": "1.71.0-next-441959d.0",
-        // Server settings for experimental server go inside `rescript` key
+        // Server configuration for v2 should be passed through settings.rescript
         "rescript": {
           "hover": {
             "supportMarkdownLinks": true,
           },
         },
-      }
-    }
+      },
+    },
   },
+}
 ```
 
-`initialization_options` are passed to the language server when it is started. They can be used to configure the language server. See [extensionConfiguration](https://github.com/rescript-lang/rescript-vscode/blob/441959d1feeaaffc1a589687758b1fbe1f649e72/server/src/config.ts#L5-L29)
-
-The `settings.version` are specific to the Zed extension.
-With `version` you can point to a specific npm version of the [@rescript/language-server](https://www.npmjs.com/package/@rescript/language-server?activeTab=versions).
+`initialization_options` are passed to the language server (pre-v2) when it is started.
+They can be used to configure the language server. See
+[extensionConfiguration](https://github.com/rescript-lang/rescript-vscode/blob/441959d1feeaaffc1a589687758b1fbe1f649e72/server/src/config.ts#L5-L29)
 
 ## Developing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how to develop this extension locally.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how to develop this
+extension locally.
 
 ## Acknowledgements
 
-This project was originally created by [humaans](https://github.com/humaans/). We're grateful for their initial work in bringing ReScript support to Zed.
+This project was originally created by [humaans](https://github.com/humaans/).
+We're grateful for their initial work in bringing ReScript support to Zed.

--- a/README.md
+++ b/README.md
@@ -9,31 +9,26 @@ This extension plugs in the following projects:
 - [@rescript/language-server](https://www.npmjs.com/package/@rescript/language-server)
   LSP
 
-## Installing the language server
+## Language Server
 
-The stable server is the default language server used by this extension. It uses
-the pre-v2 versions of `@rescript/language-server`, and the extension installs
-and updates that package automatically.
+The stable server is used by default. It is provided by the
+`@rescript/language-server` package, which the extension installs and updates
+automatically.
 
-Use `settings.version` when you need to pin a specific npm version. If it is
-omitted, Zed installs the latest published stable version.
+Use `settings.version` to pin a specific npm version. If it is omitted, Zed
+installs the latest published stable version.
 
-> [!NOTE]
-> The experimental server is the v2 language server published to npm under the
-> `dev` tag. Pin the package to the current `dev` version. See the version
-> history on
-> [npm](https://www.npmjs.com/package/@rescript/language-server?activeTab=versions).
-
-> [!TIP]
-> You can install the language server globally with
-> `npm i -g @rescript/language-server@dev` and set the binary path.
+> [!TIP] To test the experimental language server (ReScript v13), use the
+> `rescript lsp` subcommand included with the compiler. Set the binary path and
+> arguments as follows:
 >
 > ```json
 > {
 >   "lsp": {
 >     "rescript-language-server": {
 >       "binary": {
->         "path": "rescript-language-server"
+>         "path": "node_modules/.bin/rescript",
+>         "arguments": ["lsp", "--stdio"]
 >       }
 >     }
 >   }
@@ -46,7 +41,8 @@ omitted, Zed installs the latest published stable version.
 {
   "lsp": {
     "rescript-language-server": {
-      // Server configuration for pre-v2 should be passed through initialization_options
+      // Pass stable language server configuration through initialization_options
+      // See https://github.com/rescript-lang/rescript-vscode/blob/441959d1feeaaffc1a589687758b1fbe1f649e72/server/src/config.ts#L5-L29
       "initialization_options": {
         "extensionConfiguration": {
           "askToStartBuild": false,
@@ -54,7 +50,7 @@ omitted, Zed installs the latest published stable version.
       },
       "settings": {
         "version": "1.71.0-next-441959d.0",
-        // Server configuration for v2 should be passed through settings.rescript
+        // Pass experimental language server configuration through settings.rescript
         "rescript": {
           "hover": {
             "supportMarkdownLinks": true,
@@ -65,10 +61,6 @@ omitted, Zed installs the latest published stable version.
   },
 }
 ```
-
-`initialization_options` are passed to the language server (pre-v2) when it is started.
-They can be used to configure the language server. See
-[extensionConfiguration](https://github.com/rescript-lang/rescript-vscode/blob/441959d1feeaaffc1a589687758b1fbe1f649e72/server/src/config.ts#L5-L29)
 
 ## Developing
 

--- a/src/rescript.rs
+++ b/src/rescript.rs
@@ -118,8 +118,8 @@ impl zed::Extension for ReScriptExtension {
     ) -> Result<zed::Command> {
         let server_path = self.server_script_path(server_id, worktree)?;
 
-        let current_dir = env::current_dir()
-            .map_err(|e| format!("failed to get current directory: {e}"))?;
+        let current_dir =
+            env::current_dir().map_err(|e| format!("failed to get current directory: {e}"))?;
 
         Ok(zed::Command {
             command: zed::node_binary_path()?,
@@ -150,6 +150,17 @@ impl zed::Extension for ReScriptExtension {
                 }
             }
         })))
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        match zed::settings::LspSettings::for_worktree(language_server_id.as_ref(), worktree) {
+            Ok(LspSettings { settings, .. }) => Ok(settings),
+            Err(_) => Ok(None),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Forward LSP settings to ReScript server
  - Return the configured Zed LSP settings as workspace configuration so server-specific options under rescript-language-server.settings reach the
  language server.

## TODO

- [x] Update the README.md. How use the experimental server

Related https://github.com/rescript-lang/rescript/pull/8425